### PR TITLE
Add Sidebar Note to Inform about this Being a Test Instance

### DIFF
--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -7,7 +7,7 @@
 	
 	
 	<div class="panel radius">
-		<h3><a href="/events/">This is the </a></h3>
+		<h3><a href="/events/">ISC Events</a></h3>
         The <a href="/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
 		</p>
         <p>The <a href="/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="http://paypal.github.io/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="http://paypal.github.io/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/events/isc-fall-2018/">ISC.S7 event page</a>.</p>

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -5,7 +5,6 @@
         	This is not the website of the InnerSource Commons Foundation. Rather, it's an instance of our website we use for testing purposes. Please checkout <a href="https://innersourcecommons.org" style="color:#FF0000;">innersourcecommons.org</a> for the real website.
     	</div>
 	
-	
 	<div class="panel radius">
 		<h3><a href="/events/">ISC Events</a></h3>
         The <a href="/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,6 +1,13 @@
 <aside>
+	
+	<div class="panel radius" style="border-color:#FF0000;background-color:#FFCCCC">
+		<h3>Test Instance!</h3>
+        	This is not the website of the InnerSource Commons Foundation. Rather, it's an instance of our website we use for testing purposes. Please checkout <a href="https://innersourcecommons.org" style="color:#FF0000;">innersourcecommons.org</a> for the real website.
+    	</div>
+	
+	
 	<div class="panel radius">
-		<h3><a href="/events/">ISC Events</a></h3>
+		<h3><a href="/events/">This is the </a></h3>
         The <a href="/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
 		</p>
         <p>The <a href="/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="http://paypal.github.io/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="http://paypal.github.io/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/events/isc-fall-2018/">ISC.S7 event page</a>.</p>


### PR DESCRIPTION
The fact that there is an innersourcecommons.net website, might lead to confusion. A visitor might think it is the legitimate website and might be under the impression that we have only outdated contents.

This change introduces a panel in the sidebar informing visitors that this is not the real website. I used only dirty-ish CSS inline styles (so that we do not have to manipulate any CSS files and keep this testing instance as similar as possible to the production instance).