### PR TITLE
Rename Governance page and sort Board Reports

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ languages:
           identifier: about
           URL: about/commons
           weight: 4
-        - name: Board and Governance
+        - name: Board & Governance
           URL: about/board
           parent: about
           weight: 1

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ languages:
           URL: about/board
           parent: about
           weight: 1
-        - name: Code Of Conduct
+        - name: Code of Conduct
           URL: about/codeofconduct
           parent: about
           weight: 2

--- a/content/about/board/_index.md
+++ b/content/about/board/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Board and Governanance"
+title: "Board & Governance"
 type: "board"
 ---
 
@@ -27,7 +27,6 @@ Daniel Izquierdo Cortazar is a researcher and one of the founders of Bitergia, a
 {{< board-member name="Isabel Drost-Fromm" image="/images/about/Isabel_Drost-Fromm.jpeg" style="bg-light" >}}
 Isabel Drost-Fromm is Open Source Strategist at Europace AG Germany. She`s a member of the Apache Software Foundation, co-founder of Apache Mahout and mentored several incubating projects. Isabel is interested in all things FOSS, search and text mining with a decent machine learning background. True to the nature of people living in Berlin she loves having friends fly in for a brief visit - as a result she co-founded and is still one of the creative heads behind Berlin Buzzwords, a tech conference on all things search, scale and storage.
 {{< /board-member >}}
-
 {{< board-member name="Timothy H-J Yao" image="/images/about/Timothy_Yao.jpg" >}}
 Tim is a Distinguished Member of Technical Staff and the Product Line Manager for DevOps in Nokia Core Network Services. Over his twenty-four-year career in telecommunications, Tim has held roles in product management, software testing, system engineering, architecture, and procurement. He served six years on the Alcatel-Lucent FOSS Executive Committee. In the InnerSource Commons, he helped establish the InnerSource Patterns community.Tim has experience creating grass roots communities within the company and outside of it; he is a volunteer co-Municipal Liaison for National Novel Writing Month.
 {{< /board-member >}}

--- a/content/about/codeofconduct.md
+++ b/content/about/codeofconduct.md
@@ -1,5 +1,5 @@
 ---
-title: "InnerSource Commons Code Of Conduct"
+title: "InnerSource Commons Code of Conduct"
 subtitle: ""
 description: "The InnerSource Commons is a growing community of practitioners with the goal of creating and sharing knowledge about InnerSource."
 draft: false
@@ -104,7 +104,7 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by 
+Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 [homepage]: https://www.contributor-covenant.org

--- a/layouts/board/list.html
+++ b/layouts/board/list.html
@@ -16,7 +16,7 @@
         <div class="col-lg-6 col-md-7">
           <h3>Public Board Meeting Notes</h3>
           <ul>
-            {{ range .Data.Pages }}
+            {{ range sort .Data.Pages "Title" "desc" }}
             <li><a href="{{ .Permalink }}" class="btn-link">{{ .Title }} <i class="ti-arrow-right"></i></a></li>
             {{ end }}
           </ul>


### PR DESCRIPTION
Changes:

* Rename page to "Board & Governance" everywhere
* Change spelling to "Code of Conduct"
* Sort board reports from newest to oldest