### PR TITLE
Aligning company logos more vertically in the box

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -106,3 +106,7 @@ ol.breadcrumb {
 [class*=" ti-"], [class^=ti-] {
     vertical-align: -10%;
 }
+
+.company-logo {
+  margin-bottom: 0;
+}

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -1,7 +1,7 @@
 <div class="col-md-4 col-sm-6 mb-4">
   <div class="feature-card bg-light text-center">
     <div class="h-150 d-flex align-items-center justify-content-center mb-0">
-      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" class="mh-150">
+      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" class="mh-150 company-logo">
     </div>
     {{ with .Inner }}<p><cite>“{{ . }}”</cite></p> {{ end }}
     {{ if .Get "author_name" }}<a href="{{ .Get "link" }}"><b>{{ .Get "author_name" }}</b>, {{ .Get "author_title" }}</a>{{ end }}


### PR DESCRIPTION
The company logos on https://innersourcecommons.net/community/action/ were not 100% vertically aligned. 
That was especially visible for the logos at the bottom that don't have any text below it.

This PR improves that by removing the default `margin-bottom: 20px;` from the logos, by using a custom class.

I still doesn't look 100% correct for all logos, as some logo files conain white space which doesn't allow for the logo to be correctly aligned.

## Before

![logos-before](https://user-images.githubusercontent.com/163029/109151569-a3022e80-776a-11eb-80ed-72efb32c8d26.JPG)

## After

![logos-after-fixed](https://user-images.githubusercontent.com/163029/109151585-a695b580-776a-11eb-936c-f783fd1e31e5.JPG)

