### PR TITLE
Change various links to patterns book + Calendar on Community Page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,9 +21,8 @@ languages:
           weight: 3
         - name: Patterns
           parent: learn
-          URL: https://innersourcecommons.gitbook.io/innersource-patterns/
+          URL: learn/books/innersource-patterns
           weight: 4
-          pre: _blank
         - name: Events
           URL: events
           weight: 2
@@ -63,9 +62,8 @@ languages:
           URL: learn/learning-path
           weight: 3
         - name: Patterns
-          URL: https://innersourcecommons.gitbook.io/innersource-patterns/
+          URL: learn/books/innersource-patterns
           weight: 4
-          pre: _blank
       footer_middle:
         - name: Events
           URL: events

--- a/config.yaml
+++ b/config.yaml
@@ -103,9 +103,8 @@ languages:
   #         URL: ru/learn
   #         weight: 2
   #       - name: Паттерны
-  #         URL: https://innersourcecommons.gitbook.io/innersource-patterns/
+  #         URL: learn/books/innersource-patterns
   #         weight: 3
-  #         pre: _blank
   #       - name: О сообществе
   #         URL: ru/about
   #         weight: 4

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -152,6 +152,21 @@ title: "Community"
   </div>
 </section>
 
+<section class="section bg-light">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 text-center">
+        <p class="section-title mb-5 mt-3 h1">Join a Meeting</p>
+        <p>While most Working Group activities are asynchronous, some of the groups also hold meetings, to work together face to face. Below you see a list of the scheduled meetings.</p>
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=2&amp;bgcolor=%23ffffff&amp;ctz=Europe%2FBerlin&amp;src=MTVlMTdrcDhhazg1OXFsc2lybnAwYm9wNGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23D50000&amp;mode=AGENDA&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showNav=1&amp;showTitle=0" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+      </div>
+    </div>
+  </div>
+</section>
+
+
 <section class="section">
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -154,16 +154,19 @@ title: "Community"
 
 <section class="section bg-light">
   <div class="container">
-    <div class="row justify-content-center">
+    <div class="row">
       <div class="col-12 text-center">
-        <p class="section-title mb-5 mt-3 h1">Join a Meeting</p>
-        <p>While most Working Group activities are asynchronous, some of the groups also hold meetings, to work together face to face. Below you see a list of the scheduled meetings.</p>
-
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=2&amp;bgcolor=%23ffffff&amp;ctz=Europe%2FBerlin&amp;src=MTVlMTdrcDhhazg1OXFsc2lybnAwYm9wNGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23D50000&amp;mode=AGENDA&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showNav=1&amp;showTitle=0" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
+        <p class="section-title h1">Join a Meeting</p>
+        <p class="mb-4">While most Working Group activities are asynchronous, some of the groups also hold meetings, to work together face to face. <br />Feel free to participate in this meetings.</p>
+        </div>
+      </div>
+    <div class="row align-items-center justify-content-center text-center text-md-left">
+        <div class="col-md-7 mb-4 mb-md-0">
+          <iframe src="https://calendar.google.com/calendar/embed?height=400&amp;wkst=2&amp;bgcolor=%23f8f9fa&amp;ctz=America%2FNew_York&amp;src=MTVlMTdrcDhhazg1OXFsc2lybnAwYm9wNGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23616161&amp;showCalendars=0&amp;showTz=1&amp;showTabs=0&amp;showPrint=0&amp;showTitle=0&amp;showNav=0&amp;showDate=0&amp;hl=en&amp;mode=AGENDA" style="border-width:0;" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
 </section>
 
 

--- a/content/learn/books/innersource-patterns.md
+++ b/content/learn/books/innersource-patterns.md
@@ -7,11 +7,11 @@ summary: A Pattern - That's what we call InnerSource best practices codified in 
 book_author: InnerSource Commons Community
 book_publish_date: 2020 (and continuously)
 book_publisher: InnerSource Commons
-book_url: https://innersourcecommons.gitbook.io/innersource-patterns/
+book_url: https://patterns.innersourcecommons.org
 ---
 
 A Pattern - That's what we call InnerSource best practices codified in a specific format to make it easy to understand, evaluate, and apply them in your context.
 
 These patterns have been collected by the [InnerSource Commons](http://innersourcecommons.org) community over many years. The most mature patterns have been published in this book. Mature in this context means that each pattern has been reviewed by members of the community, and has at least one known instance where this pattern has been used.
 
-If you are using InnerSource in your company already and want to contribute your experiences to this book we would love to [welcome your contributions](https://innersourcecommons.gitbook.io/innersource-patterns/appendix/contribute-to-this-book)!
+If you are using InnerSource in your company already and want to contribute your experiences to this book we would love to [welcome your contributions](https://patterns.innersourcecommons.org/contribute)!

--- a/content/learn/patterns.md
+++ b/content/learn/patterns.md
@@ -1,9 +1,8 @@
 ---
 title: "InnerSource Patterns"
 description: "The Patterns Working Group is creating a book with InnerSource Patterns - best practices codified in a specific format easy to understand and reuse. It is one of our most popular learning resources and is where you will find the ideas about how to kick-start or scale your InnerSource practice."
-redirect: "https://innersourcecommons.gitbook.io/innersource-patterns/"
+redirect: "/learn/books/innersource-patterns"
 type: "redirects"
-target: "_blank"
 image: "images/learn/patterns.jpg"
 weight: 1
 ---

--- a/content/redirects/patterns.md
+++ b/content/redirects/patterns.md
@@ -2,7 +2,7 @@
 title: "InnerSource Patterns"
 description: "The Patterns Working Group is creating a book with InnerSource Patterns - best practices codified in a specific format easy to understand and reuse. It is one of our most popular learning resources and is where you will find the ideas about how to kick-start or scale your InnerSource practice."
 url: "/patterns"
-redirect: "https://innersourcecommons.gitbook.io/innersource-patterns/"
+redirect: "https://patterns.innersourcecommons.org"
 type: "redirects"
 image: "images/learn/patterns.jpg"
 ---

--- a/layouts/book/single.html
+++ b/layouts/book/single.html
@@ -15,7 +15,7 @@
             <p class="mb-0"> <b>Author:</b> {{ .Params.book_author }} </p>
             <p class="mb-0"> <b>Publication Date:</b> {{ .Params.book_publish_date }} </p>
             <p class="mb-4"> <b>Publisher:</b> {{ .Params.book_publisher }} </p>
-            <a href="{{.Params.book_url}}" class="btn btn-primary">Read the book</a>
+            <a href="{{.Params.book_url}}" target="_blank" class="btn btn-primary">Read the book</a>
           </div>
         </div>
 


### PR DESCRIPTION
Implements results of discussion https://github.com/InnerSourceCommons/innersourcecommons.net/issues/47#issuecomment-787472620

Changes:
* Rather than linking straight to the extranal page (gitbook), we first link to the book page our website. From there people can then click-through to the book
* replace references of old gitbook URL with the new one
* Embedded the Google Calendar with the working group meetings on the Community Page

## Note

The books page on our new website is now reachable via two paths:
* `/learn/patterns/`
* `/learn/books/innersource-patterns`



