### PR TITLE
Correct ordering of Learning Path sections

### DIFF
--- a/content/learn/learning-path/contributor/_index.md
+++ b/content/learn/learning-path/contributor/_index.md
@@ -6,6 +6,7 @@ contributors:
   - name: Johannes Tigges
     url: https://github.com/lenucksi
 image: "images/learn/LP_thumbnail_contributor.jpg"
+weight: 3
 ---
 
 The Contributor section covers what it means to be an InnerSource Contributor, the aspects of behaviour that will make you a successful Contributor, contribution mechanics and the benefits of InnerSource for your team and organization.

--- a/content/learn/learning-path/introduction/_index.md
+++ b/content/learn/learning-path/introduction/_index.md
@@ -5,6 +5,7 @@ contributors:
     url: https://github.com/lenucksi
 image: "images/learn/LP_thumbnail_introduction.jpg"
 featured: true
+weight: 1
 ---
 
 Check out the Introduction to learn about the types of problems where InnerSource can help, how to do it, the types of benefits you can expect to see by participating, and the underlying principles that make it all work.

--- a/content/learn/learning-path/product-owner/_index.md
+++ b/content/learn/learning-path/product-owner/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Learning Path - Product Owner
 image: "images/learn/LP_thumbnail_productowner.jpg"
+weight: 4
 ---
 
 The Product Owner section covers how this role fits into InnerSource.

--- a/content/learn/learning-path/trusted-committer/_index.md
+++ b/content/learn/learning-path/trusted-committer/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Learning Path - Trusted Committer
 image: "images/learn/LP_thumbnail_trustedcommitter.jpg"
+weight: 2
 ---
 
 The Trusted Committer section covers what it means to be an InnerSource Trusted Committer, and how to support your contributors.


### PR DESCRIPTION
As per https://innersourcecommons.org/resources/learningpath/, the correct ordering is:
1. Introduction
2. Trusted Committer
3. Contributor
4. Product Owner